### PR TITLE
Add per-task Markdown export for active Outlook tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/
+.envrc
+.idea/
+.vscode/
+*.log
+todo_state.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# Outlook Mail To-Do Synchroniser
+
+This project provides a command-line application that converts unread Outlook
+messages into a local to-do list. Each task keeps track of when the work should
+be carried out, whether it has been completed, and where to find the original
+message. When a task is marked as done, the associated e-mail is also marked as
+read within Outlook. The current task list can be exported to Markdown for
+status reporting or sharing with a wider team.
+
+## Features
+
+- Fetch unread mails from the Outlook inbox via the Microsoft Graph API
+- Persist the to-do list locally so that tasks survive between runs
+- Mark tasks as completed and flag the original e-mail as read in Outlook
+- Export the current tasks as a Markdown table
+- Keep per-task Markdown notes for every active item
+- Optional manual task entry for reminders that are not tied to a message
+
+## Requirements
+
+- Python 3.10+
+- An Azure AD application registration with access to the Microsoft Graph API
+  (client credentials flow)
+- The following environment variables must be defined before running the tool:
+  - `MS_TENANT_ID`
+  - `MS_CLIENT_ID`
+  - `MS_CLIENT_SECRET`
+- Optional: set `OUTLOOK_TODO_STORAGE` to change where the local state file is
+  stored (defaults to `todo_state.json` in the working directory)
+
+Install the dependencies using `pip`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the CLI via `python -m outlook_todo` followed by one of the sub-commands.
+
+### Synchronise unread e-mails
+
+```bash
+python -m outlook_todo sync --limit 50
+```
+
+By default, each task is scheduled for the time the message was received. To
+override the planned execution time, provide the `--schedule` flag with an ISO
+8601 timestamp:
+
+```bash
+python -m outlook_todo sync --schedule 2023-09-30T09:00
+```
+
+### List tasks
+
+```bash
+python -m outlook_todo list
+```
+
+### Mark a task as complete
+
+```bash
+python -m outlook_todo mark-done <message-id>
+```
+
+The message id is the Microsoft Graph identifier for the Outlook item. It is
+printed during the synchronisation step and stored in the `todo_state.json`
+file.
+
+### Export tasks to Markdown
+
+```bash
+python -m outlook_todo export-markdown todo.md
+```
+
+The generated Markdown file contains a table summarising the current to-do
+items. Completed tasks are annotated with ✅ while pending entries use ⬜.
+
+### Export Markdown notes for active tasks
+
+```bash
+python -m outlook_todo export-active-markdown active_tasks/
+```
+
+This command maintains one Markdown file per active task inside the provided
+directory. Files for tasks that have been completed are removed automatically so
+the folder always reflects the current queue of work.
+
+## Development
+
+Run the automated test suite with:
+
+```bash
+pytest
+```
+
+The project uses a lightweight architecture of pure Python modules so it can be
+easily extended or embedded into other tooling.

--- a/outlook_todo/__init__.py
+++ b/outlook_todo/__init__.py
@@ -1,0 +1,5 @@
+"""Synchronise unread Outlook mails with a local to-do list."""
+
+from .todo_app import OutlookTodoApp
+
+__all__ = ["OutlookTodoApp"]

--- a/outlook_todo/__main__.py
+++ b/outlook_todo/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for ``python -m outlook_todo``."""
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - delegated to CLI
+    raise SystemExit(main())

--- a/outlook_todo/cli.py
+++ b/outlook_todo/cli.py
@@ -1,0 +1,148 @@
+"""Command line interface for the Outlook to-do application."""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+from .config import AppConfig, ConfigError
+from .graph import GraphApiError, GraphClient
+from .todo_app import OutlookTodoApp
+from .storage import TodoStorage
+
+
+def _parse_schedule(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
+    return dt
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Outlook unread mail to-do synchroniser")
+    subparsers = parser.add_subparsers(dest="command")
+
+    sync_parser = subparsers.add_parser("sync", help="Import unread Outlook mails as tasks")
+    sync_parser.add_argument("--limit", type=int, default=25, help="Maximum number of emails to fetch")
+    sync_parser.add_argument(
+        "--schedule",
+        type=_parse_schedule,
+        help="Override the scheduled time for all created tasks (ISO-8601 format)",
+    )
+
+    subparsers.add_parser("list", help="List all known tasks")
+
+    done_parser = subparsers.add_parser("mark-done", help="Mark a task as complete")
+    done_parser.add_argument("message_id", help="Identifier of the underlying Outlook message")
+
+    export_parser = subparsers.add_parser("export-markdown", help="Write the current tasks to a Markdown file")
+    export_parser.add_argument("output", type=Path, nargs="?", default=Path("todo.md"))
+
+    active_md_parser = subparsers.add_parser(
+        "export-active-markdown",
+        help="Create individual Markdown files for each active task",
+    )
+    active_md_parser.add_argument(
+        "directory",
+        type=Path,
+        nargs="?",
+        default=Path("active_tasks"),
+        help="Destination directory for the per-task Markdown files",
+    )
+
+    return parser
+
+
+def _create_app(config: AppConfig) -> OutlookTodoApp:
+    storage = TodoStorage(config.storage_path)
+    graph = GraphClient(config.tenant_id, config.client_id, config.client_secret)
+    return OutlookTodoApp(graph, storage)
+
+
+def handle_sync(app: OutlookTodoApp, limit: int, schedule: datetime | None) -> int:
+    new_items = app.sync_unread_emails(limit=limit, schedule_for=schedule)
+    if not new_items:
+        print("No new unread mails were found.")
+        return 0
+    print(f"Imported {len(new_items)} mail(s) into the to-do list:")
+    for item in new_items:
+        print(f" - {item.subject} (scheduled for {item.scheduled_for.isoformat()})")
+    return 0
+
+
+def handle_list(app: OutlookTodoApp) -> int:
+    items = app.list_items()
+    if not items:
+        print("No tasks available.")
+        return 0
+    for item in items:
+        status = "Done" if item.completed else "Pending"
+        print(f"[{status}] {item.subject} — scheduled for {item.scheduled_for.isoformat()}")
+    return 0
+
+
+def handle_mark_done(app: OutlookTodoApp, message_id: str) -> int:
+    try:
+        item = app.mark_done(message_id)
+    except KeyError:
+        print(f"No task with id {message_id} exists.")
+        return 1
+    print(f"Marked '{item.subject}' as complete and flagged the original e-mail as read.")
+    return 0
+
+
+def handle_export_markdown(app: OutlookTodoApp, output: Path) -> int:
+    path = app.export_markdown(output)
+    print(f"Wrote Markdown overview to {path}")
+    return 0
+
+
+def handle_export_active_markdown(app: OutlookTodoApp, directory: Path) -> int:
+    paths = app.export_active_markdown(directory)
+    if not paths:
+        print(f"No active tasks found. Cleared Markdown directory at {directory.resolve()}.")
+        return 0
+    print(f"Wrote {len(paths)} Markdown file(s) to {directory.resolve()}:")
+    for path in paths:
+        print(f" - {path.name}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.print_help()
+        return 0
+
+    try:
+        config = AppConfig.from_env()
+    except ConfigError as exc:  # pragma: no cover - configuration is validated in runtime
+        print(str(exc))
+        return 1
+
+    app = _create_app(config)
+
+    try:
+        if args.command == "sync":
+            return handle_sync(app, limit=args.limit, schedule=args.schedule)
+        if args.command == "list":
+            return handle_list(app)
+        if args.command == "mark-done":
+            return handle_mark_done(app, args.message_id)
+        if args.command == "export-markdown":
+            return handle_export_markdown(app, args.output)
+        if args.command == "export-active-markdown":
+            return handle_export_active_markdown(app, args.directory)
+        parser.print_help()
+        return 1
+    except GraphApiError as exc:  # pragma: no cover - depends on network/API
+        print(f"Graph API error: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/outlook_todo/config.py
+++ b/outlook_todo/config.py
@@ -1,0 +1,68 @@
+"""Configuration utilities for the Outlook to-do synchroniser."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Optional
+
+
+class ConfigError(RuntimeError):
+    """Raised when required configuration values are missing."""
+
+
+@dataclass
+class AppConfig:
+    """Application configuration values.
+
+    Attributes:
+        tenant_id: Azure AD tenant id used for Microsoft Graph authentication.
+        client_id: The client id of the Azure AD application registration.
+        client_secret: The client secret of the Azure AD application registration.
+        storage_path: File system path to the JSON file where to-do state is persisted.
+    """
+
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    storage_path: Path = Path("todo_state.json")
+
+    @classmethod
+    def from_env(cls, storage_path: Optional[Path] = None) -> "AppConfig":
+        """Load configuration from the environment.
+
+        Args:
+            storage_path: Optional override for where the JSON data is stored.
+
+        Raises:
+            ConfigError: If a required environment variable is missing.
+        """
+
+        tenant_id = os.getenv("MS_TENANT_ID")
+        client_id = os.getenv("MS_CLIENT_ID")
+        client_secret = os.getenv("MS_CLIENT_SECRET")
+
+        missing = [
+            name
+            for name, value in (
+                ("MS_TENANT_ID", tenant_id),
+                ("MS_CLIENT_ID", client_id),
+                ("MS_CLIENT_SECRET", client_secret),
+            )
+            if not value
+        ]
+        if missing:
+            raise ConfigError(
+                "Missing required environment variables: " + ", ".join(missing)
+            )
+
+        if storage_path is None:
+            storage_raw = os.getenv("OUTLOOK_TODO_STORAGE", "todo_state.json")
+            storage_path = Path(storage_raw)
+
+        return cls(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+            storage_path=storage_path.expanduser().resolve(),
+        )

--- a/outlook_todo/graph.py
+++ b/outlook_todo/graph.py
@@ -1,0 +1,147 @@
+"""Thin wrapper around the Microsoft Graph API."""
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # pragma: no cover - import is environment specific
+    import msal  # type: ignore
+except ImportError:  # pragma: no cover - handled gracefully in GraphClient
+    msal = None  # type: ignore[assignment]
+
+GRAPH_API_ROOT = "https://graph.microsoft.com/v1.0"
+SCOPES = ["https://graph.microsoft.com/.default"]
+
+
+def _get_requests_module():  # pragma: no cover - trivial helper
+    try:
+        return importlib.import_module("requests")
+    except ImportError as exc:  # pragma: no cover - import depends on env
+        raise RuntimeError(
+            "The 'requests' package is required to communicate with Microsoft Graph. "
+            "Install it via 'pip install requests'."
+        ) from exc
+
+
+class GraphApiError(RuntimeError):
+    """Raised when the Microsoft Graph API returns an error response."""
+
+    def __init__(self, response: Any):
+        self.response = response
+        message = f"Graph API call failed with status {response.status_code}: {response.text}"
+        super().__init__(message)
+
+
+class GraphClient:
+    """Client for interacting with the Microsoft Graph API."""
+
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str) -> None:
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        if msal is None:
+            raise RuntimeError(
+                "The 'msal' package is required to authenticate with Microsoft Graph. "
+                "Install it via 'pip install msal'."
+            )
+        authority = f"https://login.microsoftonline.com/{tenant_id}"
+        self._client = msal.ConfidentialClientApplication(
+            client_id, authority=authority, client_credential=client_secret
+        )
+
+    # ------------------------------------------------------------------
+    # Authentication helpers
+    # ------------------------------------------------------------------
+    def _acquire_token(self) -> str:
+        result = self._client.acquire_token_silent(SCOPES, account=None)
+        if not result:
+            result = self._client.acquire_token_for_client(scopes=SCOPES)
+        if "access_token" not in result:
+            raise RuntimeError(f"Unable to obtain access token: {result.get('error_description')}")
+        return result["access_token"]
+
+    def _auth_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self._acquire_token()}"}
+
+    # ------------------------------------------------------------------
+    # Mail helpers
+    # ------------------------------------------------------------------
+    def fetch_unread_emails(self, limit: int = 25) -> List[Dict]:
+        """Return unread inbox emails ordered from newest to oldest."""
+
+        url = f"{GRAPH_API_ROOT}/me/mailFolders/Inbox/messages"
+        params = {
+            "$top": limit,
+            "$filter": "isRead eq false",
+            "$orderby": "receivedDateTime desc",
+            "$select": "id,subject,from,receivedDateTime,bodyPreview,webLink",
+        }
+        requests = _get_requests_module()
+        response = requests.get(url, headers=self._auth_headers(), params=params, timeout=30)
+        if not response.ok:
+            raise GraphApiError(response)
+        payload = response.json()
+        return payload.get("value", [])
+
+    def mark_email_as_read(self, message_id: str) -> None:
+        """Mark a message as read."""
+
+        url = f"{GRAPH_API_ROOT}/me/messages/{message_id}"
+        requests = _get_requests_module()
+        response = requests.patch(
+            url,
+            headers={**self._auth_headers(), "Content-Type": "application/json"},
+            json={"isRead": True},
+            timeout=30,
+        )
+        if response.status_code not in (200, 204):
+            raise GraphApiError(response)
+
+    # ------------------------------------------------------------------
+    # To-do helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def parse_graph_datetime(value: str) -> datetime:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    @staticmethod
+    def extract_sender(message: Dict) -> str:
+        from_data = message.get("from") or {}
+        email_address = from_data.get("emailAddress") or {}
+        return email_address.get("name") or email_address.get("address") or "Unknown sender"
+
+    @staticmethod
+    def to_todo_payload(message: Dict, default_schedule: Optional[datetime] = None) -> Dict:
+        received = GraphClient.parse_graph_datetime(message["receivedDateTime"])
+        scheduled = default_schedule or received
+        return {
+            "message_id": message["id"],
+            "subject": message.get("subject") or "(no subject)",
+            "sender": GraphClient.extract_sender(message),
+            "received_at": received,
+            "scheduled_for": scheduled,
+            "body_preview": message.get("bodyPreview", ""),
+            "web_link": message.get("webLink"),
+        }
+
+
+class InMemoryGraphClient(GraphClient):  # pragma: no cover - used for demos/testing
+    """Graph client used for tests or demos without network access."""
+
+    def __init__(self, messages: Iterable[Dict]):
+        self.messages = list(messages)
+
+    def fetch_unread_emails(self, limit: int = 25) -> List[Dict]:
+        return self.messages[:limit]
+
+    def mark_email_as_read(self, message_id: str) -> None:
+        for message in self.messages:
+            if message.get("id") == message_id:
+                message["isRead"] = True
+                break

--- a/outlook_todo/markdown.py
+++ b/outlook_todo/markdown.py
@@ -1,0 +1,50 @@
+"""Utilities for exporting the to-do list as Markdown."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from .models import TodoItem
+
+
+def format_datetime(value: datetime) -> str:
+    """Format the datetime for human-friendly display."""
+
+    return value.astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def to_markdown(items: Iterable[TodoItem]) -> str:
+    """Produce a Markdown table representation of todo items."""
+
+    rows = [
+        "| Subject | Sender | Scheduled | Status |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in items:
+        subject = item.subject.replace("|", r"\|")
+        sender = item.sender.replace("|", r"\|")
+        scheduled = format_datetime(item.scheduled_for)
+        status = "✅" if item.completed else "⬜"
+        rows.append(f"| {subject} | {sender} | {scheduled} | {status} |")
+    if len(rows) == 2:
+        rows.append("| _No tasks available_ |  |  |  |")
+    return "\n".join(rows)
+
+
+def item_to_markdown(item: TodoItem) -> str:
+    """Return a Markdown document describing a single to-do item."""
+
+    status_label = "✅ Done" if item.completed else "⬜ Pending"
+    lines = [
+        f"# {item.subject or '(no subject)'}",
+        "",
+        f"- **Sender:** {item.sender}",
+        f"- **Received:** {format_datetime(item.received_at)}",
+        f"- **Scheduled:** {format_datetime(item.scheduled_for)}",
+        f"- **Status:** {status_label}",
+    ]
+    if item.web_link:
+        lines.append(f"- **Link:** {item.web_link}")
+    if item.body_preview:
+        lines.extend(["", "## Preview", "", item.body_preview])
+    return "\n".join(lines).strip() + "\n"

--- a/outlook_todo/models.py
+++ b/outlook_todo/models.py
@@ -1,0 +1,78 @@
+"""Data models for Outlook-derived to-do items."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def _ensure_tz(value: datetime) -> datetime:
+    """Ensure a datetime instance is timezone aware."""
+    if value.tzinfo is None:
+        raise ValueError("datetime values must be timezone aware")
+    return value
+
+
+def _parse_datetime(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(value)
+
+
+@dataclass
+class TodoItem:
+    """Represents a to-do entry created from an Outlook e-mail."""
+
+    message_id: str
+    subject: str
+    sender: str
+    received_at: datetime
+    scheduled_for: datetime
+    body_preview: str = ""
+    web_link: str | None = None
+    completed: bool = False
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self) -> None:
+        self.received_at = _ensure_tz(self.received_at)
+        self.scheduled_for = _ensure_tz(self.scheduled_for)
+        if self.created_at.tzinfo is None:
+            self.created_at = self.created_at.replace(tzinfo=timezone.utc)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the item to a JSON-compatible dictionary."""
+
+        return {
+            "message_id": self.message_id,
+            "subject": self.subject,
+            "sender": self.sender,
+            "received_at": self.received_at.isoformat(),
+            "scheduled_for": self.scheduled_for.isoformat(),
+            "body_preview": self.body_preview,
+            "web_link": self.web_link,
+            "completed": self.completed,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "TodoItem":
+        """Reconstruct a :class:`TodoItem` from persisted data."""
+
+        created_raw = payload.get("created_at", datetime.now(timezone.utc).isoformat())
+        return cls(
+            message_id=payload["message_id"],
+            subject=payload["subject"],
+            sender=payload["sender"],
+            received_at=_parse_datetime(payload["received_at"]),
+            scheduled_for=_parse_datetime(payload["scheduled_for"]),
+            body_preview=payload.get("body_preview", ""),
+            web_link=payload.get("web_link"),
+            completed=payload.get("completed", False),
+            created_at=_parse_datetime(created_raw),
+        )
+
+    @property
+    def status(self) -> str:
+        """Return the textual representation of the completion status."""
+
+        return "Done" if self.completed else "Pending"

--- a/outlook_todo/storage.py
+++ b/outlook_todo/storage.py
@@ -1,0 +1,83 @@
+"""Persistence helpers for to-do items."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .models import TodoItem
+
+
+class TodoStorage:
+    """File-system backed storage for :class:`TodoItem` instances."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._items: Dict[str, TodoItem] = {}
+        if self.path.exists():
+            self._load()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self._items = {
+            item_data["message_id"]: TodoItem.from_dict(item_data)
+            for item_data in data
+        }
+
+    def save(self) -> None:
+        """Persist the current state to disk."""
+
+        serialised: List[Dict] = [item.to_dict() for item in self._items.values()]
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(serialised, indent=2), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def add(self, item: TodoItem, overwrite: bool = False) -> None:
+        """Store a new :class:`TodoItem`.
+
+        Args:
+            item: The to-do item to persist.
+            overwrite: Whether to overwrite an existing entry with the same
+                message id.
+        """
+
+        if not overwrite and item.message_id in self._items:
+            raise KeyError(f"Item with id {item.message_id} already exists")
+        self._items[item.message_id] = item
+
+    def get(self, message_id: str) -> TodoItem | None:
+        """Retrieve an item by its message id."""
+
+        return self._items.get(message_id)
+
+    def update(self, item: TodoItem) -> None:
+        """Persist updates for an existing item."""
+
+        if item.message_id not in self._items:
+            raise KeyError(f"Cannot update missing item {item.message_id}")
+        self._items[item.message_id] = item
+
+    def remove(self, message_id: str) -> None:
+        """Remove an item from storage."""
+
+        if message_id in self._items:
+            del self._items[message_id]
+
+    def all(self) -> List[TodoItem]:
+        """Return all stored items sorted by their scheduled time."""
+
+        return sorted(self._items.values(), key=lambda item: item.scheduled_for)
+
+    def extend(self, items: Iterable[TodoItem], overwrite: bool = False) -> None:
+        """Store multiple items at once."""
+
+        for item in items:
+            self.add(item, overwrite=overwrite)
+
+    def __contains__(self, message_id: str) -> bool:  # pragma: no cover - simple alias
+        return message_id in self._items

--- a/outlook_todo/todo_app.py
+++ b/outlook_todo/todo_app.py
@@ -1,0 +1,132 @@
+"""Core orchestration logic for syncing Outlook emails to to-do items."""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import List, Sequence
+
+from .graph import GraphClient
+from .markdown import item_to_markdown, to_markdown
+from .models import TodoItem
+from .storage import TodoStorage
+
+
+class OutlookTodoApp:
+    """High level interface for the Outlook to-do synchroniser."""
+
+    def __init__(self, graph_client: GraphClient, storage: TodoStorage) -> None:
+        self.graph_client = graph_client
+        self.storage = storage
+
+    # ------------------------------------------------------------------
+    # Synchronisation
+    # ------------------------------------------------------------------
+    def sync_unread_emails(self, limit: int = 25, schedule_for: datetime | None = None) -> List[TodoItem]:
+        """Convert unread emails to to-do entries.
+
+        Args:
+            limit: Maximum number of unread messages to fetch.
+            schedule_for: Optional datetime indicating when the tasks should be
+                executed. Defaults to the received time of the message.
+        """
+
+        messages = self.graph_client.fetch_unread_emails(limit=limit)
+        new_items: List[TodoItem] = []
+        for message in messages:
+            message_id = message["id"]
+            if message_id in self.storage:
+                continue
+            payload = self.graph_client.to_todo_payload(message, default_schedule=schedule_for)
+            todo = TodoItem(**payload)
+            self.storage.add(todo, overwrite=True)
+            new_items.append(todo)
+        if new_items:
+            self.storage.save()
+        return new_items
+
+    def list_items(self) -> Sequence[TodoItem]:
+        """Return all known to-do entries."""
+
+        return self.storage.all()
+
+    def mark_done(self, message_id: str) -> TodoItem:
+        """Mark the matching to-do item as completed and flag the email as read."""
+
+        item = self.storage.get(message_id)
+        if item is None:
+            raise KeyError(f"No todo item found with id {message_id}")
+        if item.completed:
+            return item
+        self.graph_client.mark_email_as_read(message_id)
+        item.completed = True
+        self.storage.update(item)
+        self.storage.save()
+        return item
+
+    def export_markdown(self, output_path: Path) -> Path:
+        """Write the current to-do list to *output_path* in Markdown format."""
+
+        markdown = to_markdown(self.storage.all())
+        output_path = output_path.expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(markdown, encoding="utf-8")
+        return output_path
+
+    def export_active_markdown(self, output_dir: Path) -> List[Path]:
+        """Write individual Markdown files for each active (pending) task."""
+
+        output_dir = output_dir.expanduser().resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        def _safe_component(value: str) -> str:
+            value = value.strip() or "task"
+            return re.sub(r"[^A-Za-z0-9._-]", "_", value)
+
+        def _filename_for(item: TodoItem) -> str:
+            subject_slug = _safe_component(item.subject)
+            id_slug = _safe_component(item.message_id)
+            return f"{subject_slug}-{id_slug}.md"
+
+        active_items = [item for item in self.storage.all() if not item.completed]
+        written_paths: List[Path] = []
+        for item in active_items:
+            filename = _filename_for(item)
+            path = output_dir / filename
+            path.write_text(item_to_markdown(item), encoding="utf-8")
+            written_paths.append(path)
+
+        existing_files = {p for p in output_dir.glob("*.md")}
+        for path in existing_files - set(written_paths):
+            path.unlink()
+
+        return sorted(written_paths)
+
+    def add_manual_item(
+        self,
+        subject: str,
+        sender: str,
+        scheduled_for: datetime,
+        body_preview: str = "",
+        web_link: str | None = None,
+    ) -> TodoItem:
+        """Add an ad-hoc task to the to-do list."""
+
+        message_id = f"manual-{len(self.storage.all())+1}"
+        todo = TodoItem(
+            message_id=message_id,
+            subject=subject,
+            sender=sender,
+            received_at=scheduled_for,
+            scheduled_for=scheduled_for,
+            body_preview=body_preview,
+            web_link=web_link,
+        )
+        self.storage.add(todo, overwrite=True)
+        self.storage.save()
+        return todo
+
+    def export_markdown_string(self) -> str:
+        """Return the Markdown representation without touching disk."""
+
+        return to_markdown(self.storage.all())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+msal>=1.23.0
+requests>=2.31.0
+pytest>=7.4.0

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+
+from outlook_todo.markdown import item_to_markdown, to_markdown
+from outlook_todo.models import TodoItem
+
+
+def make_item(subject: str, completed: bool = False) -> TodoItem:
+    now = datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc)
+    return TodoItem(
+        message_id=f"id-{subject}",
+        subject=subject,
+        sender="sender@example.com",
+        received_at=now,
+        scheduled_for=now,
+        completed=completed,
+    )
+
+
+def test_to_markdown_with_items():
+    items = [make_item("Task A"), make_item("Task B", completed=True)]
+    markdown = to_markdown(items)
+    assert "Task A" in markdown
+    assert "Task B" in markdown
+    assert "⬜" in markdown
+    assert "✅" in markdown
+
+
+def test_to_markdown_empty_list():
+    markdown = to_markdown([])
+    assert "No tasks available" in markdown
+
+
+def test_item_to_markdown_includes_details():
+    item = make_item("Important", completed=True)
+    item.body_preview = "Details go here"
+    item.web_link = "https://example.com"
+    markdown = item_to_markdown(item)
+    assert "# Important" in markdown
+    assert "✅ Done" in markdown
+    assert "Details go here" in markdown
+    assert "https://example.com" in markdown

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+from outlook_todo.models import TodoItem
+from outlook_todo.storage import TodoStorage
+
+
+def make_item(identifier: str) -> TodoItem:
+    now = datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc)
+    return TodoItem(
+        message_id=identifier,
+        subject="Subject",
+        sender="sender@example.com",
+        received_at=now,
+        scheduled_for=now,
+    )
+
+
+def test_storage_roundtrip(tmp_path):
+    storage_path = tmp_path / "state.json"
+    storage = TodoStorage(storage_path)
+
+    item = make_item("abc")
+    storage.add(item)
+    storage.save()
+
+    loaded = TodoStorage(storage_path)
+    assert loaded.get("abc").subject == "Subject"
+
+
+def test_storage_prevents_duplicates(tmp_path):
+    storage = TodoStorage(tmp_path / "state.json")
+    item = make_item("dup")
+    storage.add(item)
+    try:
+        storage.add(item)
+    except KeyError:
+        pass
+    else:  # pragma: no cover - defensive programming
+        raise AssertionError("Expected duplicate entry to raise KeyError")

--- a/tests/test_todo_app.py
+++ b/tests/test_todo_app.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+
+from outlook_todo.graph import InMemoryGraphClient
+from outlook_todo.todo_app import OutlookTodoApp
+from outlook_todo.storage import TodoStorage
+
+
+NOW = datetime(2023, 1, 1, 9, 0, tzinfo=timezone.utc)
+
+
+class DummyGraph(InMemoryGraphClient):
+    def __init__(self):
+        messages = [
+            {
+                "id": "1",
+                "subject": "Subject 1",
+                "from": {"emailAddress": {"name": "Alice"}},
+                "receivedDateTime": NOW.isoformat(),
+                "bodyPreview": "Hello",
+                "webLink": "https://outlook.example/1",
+            }
+        ]
+        super().__init__(messages)
+
+
+def create_app(tmp_path) -> OutlookTodoApp:
+    graph = DummyGraph()
+    storage = TodoStorage(tmp_path / "state.json")
+    return OutlookTodoApp(graph, storage)
+
+
+def test_sync_creates_items(tmp_path):
+    app = create_app(tmp_path)
+    created = app.sync_unread_emails()
+    assert len(created) == 1
+    stored = app.list_items()
+    assert stored[0].subject == "Subject 1"
+
+
+def test_mark_done_marks_email(tmp_path):
+    app = create_app(tmp_path)
+    app.sync_unread_emails()
+    app.mark_done("1")
+    assert app.list_items()[0].completed is True
+
+
+def test_export_markdown(tmp_path):
+    app = create_app(tmp_path)
+    app.sync_unread_emails()
+    output = tmp_path / "todo.md"
+    path = app.export_markdown(output)
+    assert path == output
+    assert path.exists()
+
+
+def test_export_active_markdown(tmp_path):
+    app = create_app(tmp_path)
+    app.sync_unread_emails()
+    directory = tmp_path / "active"
+
+    written = app.export_active_markdown(directory)
+    assert len(written) == 1
+    assert written[0].read_text(encoding="utf-8").startswith("# Subject 1")
+
+    app.mark_done("1")
+    written = app.export_active_markdown(directory)
+    assert written == []
+    assert list(directory.glob("*.md")) == []


### PR DESCRIPTION
## Summary
- create a Python CLI that converts unread Outlook emails into a persistent to-do list
- add Markdown export, completion handling that marks original emails as read, and configuration helpers
- document setup and add tests covering storage, markdown export, and orchestration logic
- add per-task Markdown exports and a CLI command to maintain Markdown notes for active tasks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c94aa5af20832fbf8a87e6753d2691